### PR TITLE
Fe dev feat#47: 마이페이지/내 차 목록 템플릿 구현

### DIFF
--- a/AutoBid_FE/design/my_page/myPage.css
+++ b/AutoBid_FE/design/my_page/myPage.css
@@ -1,0 +1,122 @@
+@import "../css/reset.css";
+@import "../css/common.css";
+
+.my-page__sidebar {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  margin: auto auto 64px;
+  max-width: var(--container-max-width);
+  padding: var(--container-padding);
+}
+
+.my-page__main__ul {
+  display: flex;
+  flex-direction: column;
+}
+
+.main__card-list__select-btn-group {
+  border-bottom: 1px solid lightgray;
+  display: flex;
+  justify-content: space-evenly;
+}
+
+.main__card-list__select-btn-group__btn {
+  border-bottom: 1px solid transparent;
+  font-size: 20px;
+  padding: 0 20px 15px;
+  transition: 0.1s;
+}
+
+.main__card-list__select-btn-group__btn--selected,
+.main__card-list__select-btn-group__btn:hover {
+  border-bottom: 1px solid var(--color-blue);
+  color: var(--color-blue);
+}
+
+.my-page__main__card-list {
+  display: flex;
+  gap: 36px;
+  padding: 32px 0;
+}
+
+.main__card-list__grid__item {
+  border-radius: 15px;
+  box-shadow: var(--box-shadow-level-1);
+  display: inline-block;
+  transition: 0.1s;
+  width: 250px;
+}
+
+.main__card-list__grid__item:hover {
+  transform: scale(1.02);
+}
+
+.main__card-list__grid__item__img-group {
+  align-items: center;
+  border-top-left-radius: 15px;
+  border-top-right-radius: 15px;
+  display: flex;
+  height: 140px;
+  overflow: hidden;
+}
+
+.main__card-list__grid__item__img {
+  width: 250px;
+}
+
+.main__card-list__grid__item__img-swap-btn-group {
+  display: flex;
+  height: 140px;
+  justify-content: space-between;
+  opacity: 0;
+  position: absolute;
+  transition: 0.5s;
+  width: 250px;
+  z-index: 1;
+}
+
+.main__card-list__grid__item__img-swap-btn-group:hover {
+  opacity: 0.5;
+}
+
+.grid__item__img-swap-btn-group__btn {
+  color: white;
+  margin: 5px
+}
+
+.main__card-list__grid__item__details {
+  cursor: pointer;
+  padding: 16px;
+  text-align: left;
+}
+
+.grid__item__details__tags {
+  color: var(--color-semi-blue);
+  display: block;
+  margin-bottom: 8px;
+}
+
+.grid__item__details__title {
+  display: block;
+  font-size: 20px;
+  font-weight: bold;
+  margin-bottom: 8px;
+}
+
+.grid__item__details__infos {
+  display: block;
+  margin-bottom: 16px;
+  opacity: 0.6;
+}
+
+.grid__item__details__price {
+  align-items: baseline;
+  display: flex;
+}
+
+.grid__item__details__price b {
+  color: var(--color-blue);
+  font-size: 25px;
+  margin-right: 4px;
+}

--- a/AutoBid_FE/design/my_page/myPage.css
+++ b/AutoBid_FE/design/my_page/myPage.css
@@ -1,43 +1,76 @@
 @import "../css/reset.css";
 @import "../css/common.css";
 
+body {
+  background-color: var(--color-light-gray);
+}
+
+hr {
+  border-bottom: 1px solid var(--color-semi-gray);
+  border-top: 0;
+  margin: 16px 0;
+}
+
+.my-page {
+  display: flex;
+}
+
+/* Sidebar */
 .my-page__sidebar {
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  margin: auto auto 64px;
+  min-width: 300px;
   max-width: var(--container-max-width);
   padding: var(--container-padding);
+  margin-bottom: 64px;
+  margin-right: 16px;
+  margin-left: 16px;
+  background-color: var(--color-white);
+  border-radius: 16px;
 }
 
+.my-page__sidebar__title {
+  font-size: 24px;
+  font-weight: bold;
+  margin-top: 32px;
+}
+
+.my-page__sidebar__info-holder > li {
+  padding-top: 8px;
+}
+
+.my-page__sidebar__greeting {
+  text-align: center;
+}
+
+.my-page__sidebar__phone-number {
+  margin-top: 16px;
+}
+
+/* Main */
 .my-page__main__ul {
   display: flex;
   flex-direction: column;
+  /*padding-top: 32px;*/
+  /*padding-left: 16px;*/
+  padding: var(--container-padding);
+  margin-left: 16px;
+  margin-bottom: 64px;
+  background-color: var(--color-white);
+  border-radius: 16px;
 }
 
-.main__card-list__select-btn-group {
-  border-bottom: 1px solid lightgray;
-  display: flex;
-  justify-content: space-evenly;
+.my-page__main__card-list > h3 {
+  font-size: 24px;
+  font-weight: bold;
 }
 
-.main__card-list__select-btn-group__btn {
-  border-bottom: 1px solid transparent;
-  font-size: 20px;
-  padding: 0 20px 15px;
-  transition: 0.1s;
-}
-
-.main__card-list__select-btn-group__btn--selected,
-.main__card-list__select-btn-group__btn:hover {
-  border-bottom: 1px solid var(--color-blue);
-  color: var(--color-blue);
-}
+/* Below code is from body.css (card part) */
 
 .my-page__main__card-list {
   display: flex;
-  gap: 36px;
-  padding: 32px 0;
+  flex-direction: column;
+  padding-top: 32px;
 }
 
 .main__card-list__grid__item {
@@ -46,6 +79,7 @@
   display: inline-block;
   transition: 0.1s;
   width: 250px;
+  margin: 8px 8px 32px;
 }
 
 .main__card-list__grid__item:hover {

--- a/AutoBid_FE/design/my_page/myPage.html
+++ b/AutoBid_FE/design/my_page/myPage.html
@@ -1,225 +1,227 @@
 <link rel="stylesheet" href="myPage.css">
 <body>
-<!-- MyPage Sidebar -->
-<div class="my-page__sidebar">
-    <h4 class="my-page__sidebar__title">마이 페이지</h4>
-    <hr>
-    <ul class="my-page__sidebar__div">
-        <li class="my-page__sidebar__greeting1">조재현 고객님</li>
-        <li class="my-page__sidebar__greeting2">반갑습니다.</li>
-        <li class="my-page__sidebar__phone-number">연락처: 010-1234-1234</li>
-        <li class="my-page__sidebar__email">이메일: hyunrice98@gmail.com</li>
+<div class="my-page">
+    <!-- MyPage Sidebar -->
+    <div class="my-page__sidebar">
+        <h4 class="my-page__sidebar__title">마이 페이지</h4>
+        <hr>
+        <ul class="my-page__sidebar__info-holder">
+            <li class="my-page__sidebar__greeting"><b>조재현</b> 고객님</li>
+            <li class="my-page__sidebar__greeting">반갑습니다.</li>
+            <li class="my-page__sidebar__phone-number">연락처: 010-1234-1234</li>
+            <li class="my-page__sidebar__email">이메일: hyunrice98@gmail.com</li>
+        </ul>
+    </div>
+
+    <!-- MyPage Main -->
+    <ul class="my-page__main__ul">
+        <li class="my-page__main__card-list my-page__main__my-car-list__holder">
+            <h3>참여 경매</h3>
+            <hr>
+            <ol class="my-page__main__my-car-list">
+                <li class="main__card-list__grid__item">
+                    <div class="main__card-list__grid__item__img-swap-btn-group">
+                        <button class="grid__item__img-swap-btn-group__btn">
+                            <i class="fas fa-chevron-left fa-lg"></i>
+                        </button>
+                        <button class="grid__item__img-swap-btn-group__btn">
+                            <i class="fas fa-chevron-right fa-lg"></i>
+                        </button>
+                    </div>
+                    <div class="main__card-list__grid__item__img-group">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    </div>
+                    <div class="main__card-list__grid__item__details">
+                        <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                        <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                        <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
+                        <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
+                    </div>
+                </li>
+                <li class="main__card-list__grid__item">
+                    <div class="main__card-list__grid__item__img-swap-btn-group">
+                        <button class="grid__item__img-swap-btn-group__btn">
+                            <i class="fas fa-chevron-left fa-lg"></i>
+                        </button>
+                        <button class="grid__item__img-swap-btn-group__btn">
+                            <i class="fas fa-chevron-right fa-lg"></i>
+                        </button>
+                    </div>
+                    <div class="main__card-list__grid__item__img-group">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    </div>
+                    <div class="main__card-list__grid__item__details">
+                        <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                        <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                        <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
+                        <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
+                    </div>
+                </li>
+                <li class="main__card-list__grid__item">
+                    <div class="main__card-list__grid__item__img-swap-btn-group">
+                        <button class="grid__item__img-swap-btn-group__btn">
+                            <i class="fas fa-chevron-left fa-lg"></i>
+                        </button>
+                        <button class="grid__item__img-swap-btn-group__btn">
+                            <i class="fas fa-chevron-right fa-lg"></i>
+                        </button>
+                    </div>
+                    <div class="main__card-list__grid__item__img-group">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    </div>
+                    <div class="main__card-list__grid__item__details">
+                        <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                        <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                        <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
+                        <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
+                    </div>
+                </li>
+            </ol>
+        </li>
+        <li class="my-page__main__card-list my-page__main__participating-bids__holder">
+            <h3>등록 경매</h3>
+            <hr>
+            <ol class="my-page__main__participating-bids">
+                <li class="main__card-list__grid__item">
+                    <div class="main__card-list__grid__item__img-swap-btn-group">
+                        <button class="grid__item__img-swap-btn-group__btn">
+                            <i class="fas fa-chevron-left fa-lg"></i>
+                        </button>
+                        <button class="grid__item__img-swap-btn-group__btn">
+                            <i class="fas fa-chevron-right fa-lg"></i>
+                        </button>
+                    </div>
+                    <div class="main__card-list__grid__item__img-group">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    </div>
+                    <div class="main__card-list__grid__item__details">
+                        <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                        <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                        <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
+                        <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
+                    </div>
+                </li>
+                <li class="main__card-list__grid__item">
+                    <div class="main__card-list__grid__item__img-swap-btn-group">
+                        <button class="grid__item__img-swap-btn-group__btn">
+                            <i class="fas fa-chevron-left fa-lg"></i>
+                        </button>
+                        <button class="grid__item__img-swap-btn-group__btn">
+                            <i class="fas fa-chevron-right fa-lg"></i>
+                        </button>
+                    </div>
+                    <div class="main__card-list__grid__item__img-group">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    </div>
+                    <div class="main__card-list__grid__item__details">
+                        <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                        <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                        <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
+                        <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
+                    </div>
+                </li>
+                <li class="main__card-list__grid__item">
+                    <div class="main__card-list__grid__item__img-swap-btn-group">
+                        <button class="grid__item__img-swap-btn-group__btn">
+                            <i class="fas fa-chevron-left fa-lg"></i>
+                        </button>
+                        <button class="grid__item__img-swap-btn-group__btn">
+                            <i class="fas fa-chevron-right fa-lg"></i>
+                        </button>
+                    </div>
+                    <div class="main__card-list__grid__item__img-group">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    </div>
+                    <div class="main__card-list__grid__item__details">
+                        <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                        <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                        <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
+                        <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
+                    </div>
+                </li>
+            </ol>
+        </li>
+        <li class="my-page__main__card-list my-page__main__registered-bids__holder">
+            <h3>내 차 목록</h3>
+            <hr>
+            <ol class="my-page__main__registered-bids">
+                <li class="main__card-list__grid__item">
+                    <div class="main__card-list__grid__item__img-swap-btn-group">
+                        <button class="grid__item__img-swap-btn-group__btn">
+                            <i class="fas fa-chevron-left fa-lg"></i>
+                        </button>
+                        <button class="grid__item__img-swap-btn-group__btn">
+                            <i class="fas fa-chevron-right fa-lg"></i>
+                        </button>
+                    </div>
+                    <div class="main__card-list__grid__item__img-group">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    </div>
+                    <div class="main__card-list__grid__item__details">
+                        <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                        <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                        <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
+                        <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
+                    </div>
+                </li>
+                <li class="main__card-list__grid__item">
+                    <div class="main__card-list__grid__item__img-swap-btn-group">
+                        <button class="grid__item__img-swap-btn-group__btn">
+                            <i class="fas fa-chevron-left fa-lg"></i>
+                        </button>
+                        <button class="grid__item__img-swap-btn-group__btn">
+                            <i class="fas fa-chevron-right fa-lg"></i>
+                        </button>
+                    </div>
+                    <div class="main__card-list__grid__item__img-group">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    </div>
+                    <div class="main__card-list__grid__item__details">
+                        <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                        <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                        <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
+                        <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
+                    </div>
+                </li>
+                <li class="main__card-list__grid__item">
+                    <div class="main__card-list__grid__item__img-swap-btn-group">
+                        <button class="grid__item__img-swap-btn-group__btn">
+                            <i class="fas fa-chevron-left fa-lg"></i>
+                        </button>
+                        <button class="grid__item__img-swap-btn-group__btn">
+                            <i class="fas fa-chevron-right fa-lg"></i>
+                        </button>
+                    </div>
+                    <div class="main__card-list__grid__item__img-group">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                        <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    </div>
+                    <div class="main__card-list__grid__item__details">
+                        <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                        <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                        <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
+                        <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
+                    </div>
+                </li>
+            </ol>
+        </li>
     </ul>
 </div>
-
-<!-- MyPage Main -->
-<ul class="my-page__main__ul">
-    <li class="my-page__main__card-list my-page__main__my-car-list__holder">
-        <h3>참여 경매</h3>
-        <hr>
-        <ol class="my-page__main__my-car-list">
-            <li class="main__card-list__grid__item">
-                <div class="main__card-list__grid__item__img-swap-btn-group">
-                    <button class="grid__item__img-swap-btn-group__btn">
-                        <i class="fas fa-chevron-left fa-lg"></i>
-                    </button>
-                    <button class="grid__item__img-swap-btn-group__btn">
-                        <i class="fas fa-chevron-right fa-lg"></i>
-                    </button>
-                </div>
-                <div class="main__card-list__grid__item__img-group">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                </div>
-                <div class="main__card-list__grid__item__details">
-                    <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
-                    <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
-                    <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
-                    <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
-                </div>
-            </li>
-            <li class="main__card-list__grid__item">
-                <div class="main__card-list__grid__item__img-swap-btn-group">
-                    <button class="grid__item__img-swap-btn-group__btn">
-                        <i class="fas fa-chevron-left fa-lg"></i>
-                    </button>
-                    <button class="grid__item__img-swap-btn-group__btn">
-                        <i class="fas fa-chevron-right fa-lg"></i>
-                    </button>
-                </div>
-                <div class="main__card-list__grid__item__img-group">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                </div>
-                <div class="main__card-list__grid__item__details">
-                    <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
-                    <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
-                    <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
-                    <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
-                </div>
-            </li>
-            <li class="main__card-list__grid__item">
-                <div class="main__card-list__grid__item__img-swap-btn-group">
-                    <button class="grid__item__img-swap-btn-group__btn">
-                        <i class="fas fa-chevron-left fa-lg"></i>
-                    </button>
-                    <button class="grid__item__img-swap-btn-group__btn">
-                        <i class="fas fa-chevron-right fa-lg"></i>
-                    </button>
-                </div>
-                <div class="main__card-list__grid__item__img-group">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                </div>
-                <div class="main__card-list__grid__item__details">
-                    <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
-                    <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
-                    <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
-                    <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
-                </div>
-            </li>
-        </ol>
-    </li>
-    <li class="my-page__main__card-list my-page__main__participating-bids__holder">
-        <h3>등록 경매</h3>
-        <hr>
-        <ol class="my-page__main__participating-bids">
-            <li class="main__card-list__grid__item">
-                <div class="main__card-list__grid__item__img-swap-btn-group">
-                    <button class="grid__item__img-swap-btn-group__btn">
-                        <i class="fas fa-chevron-left fa-lg"></i>
-                    </button>
-                    <button class="grid__item__img-swap-btn-group__btn">
-                        <i class="fas fa-chevron-right fa-lg"></i>
-                    </button>
-                </div>
-                <div class="main__card-list__grid__item__img-group">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                </div>
-                <div class="main__card-list__grid__item__details">
-                    <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
-                    <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
-                    <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
-                    <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
-                </div>
-            </li>
-            <li class="main__card-list__grid__item">
-                <div class="main__card-list__grid__item__img-swap-btn-group">
-                    <button class="grid__item__img-swap-btn-group__btn">
-                        <i class="fas fa-chevron-left fa-lg"></i>
-                    </button>
-                    <button class="grid__item__img-swap-btn-group__btn">
-                        <i class="fas fa-chevron-right fa-lg"></i>
-                    </button>
-                </div>
-                <div class="main__card-list__grid__item__img-group">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                </div>
-                <div class="main__card-list__grid__item__details">
-                    <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
-                    <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
-                    <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
-                    <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
-                </div>
-            </li>
-            <li class="main__card-list__grid__item">
-                <div class="main__card-list__grid__item__img-swap-btn-group">
-                    <button class="grid__item__img-swap-btn-group__btn">
-                        <i class="fas fa-chevron-left fa-lg"></i>
-                    </button>
-                    <button class="grid__item__img-swap-btn-group__btn">
-                        <i class="fas fa-chevron-right fa-lg"></i>
-                    </button>
-                </div>
-                <div class="main__card-list__grid__item__img-group">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                </div>
-                <div class="main__card-list__grid__item__details">
-                    <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
-                    <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
-                    <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
-                    <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
-                </div>
-            </li>
-        </ol>
-    </li>
-    <li class="my-page__main__card-list my-page__main__registered-bids__holder">
-        <h3>내 차 목록</h3>
-        <hr>
-        <ol class="my-page__main__registered-bids">
-            <li class="main__card-list__grid__item">
-                <div class="main__card-list__grid__item__img-swap-btn-group">
-                    <button class="grid__item__img-swap-btn-group__btn">
-                        <i class="fas fa-chevron-left fa-lg"></i>
-                    </button>
-                    <button class="grid__item__img-swap-btn-group__btn">
-                        <i class="fas fa-chevron-right fa-lg"></i>
-                    </button>
-                </div>
-                <div class="main__card-list__grid__item__img-group">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                </div>
-                <div class="main__card-list__grid__item__details">
-                    <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
-                    <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
-                    <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
-                    <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
-                </div>
-            </li>
-            <li class="main__card-list__grid__item">
-                <div class="main__card-list__grid__item__img-swap-btn-group">
-                    <button class="grid__item__img-swap-btn-group__btn">
-                        <i class="fas fa-chevron-left fa-lg"></i>
-                    </button>
-                    <button class="grid__item__img-swap-btn-group__btn">
-                        <i class="fas fa-chevron-right fa-lg"></i>
-                    </button>
-                </div>
-                <div class="main__card-list__grid__item__img-group">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                </div>
-                <div class="main__card-list__grid__item__details">
-                    <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
-                    <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
-                    <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
-                    <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
-                </div>
-            </li>
-            <li class="main__card-list__grid__item">
-                <div class="main__card-list__grid__item__img-swap-btn-group">
-                    <button class="grid__item__img-swap-btn-group__btn">
-                        <i class="fas fa-chevron-left fa-lg"></i>
-                    </button>
-                    <button class="grid__item__img-swap-btn-group__btn">
-                        <i class="fas fa-chevron-right fa-lg"></i>
-                    </button>
-                </div>
-                <div class="main__card-list__grid__item__img-group">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
-                </div>
-                <div class="main__card-list__grid__item__details">
-                    <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
-                    <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
-                    <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
-                    <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
-                </div>
-            </li>
-        </ol>
-    </li>
-</ul>
 </body>

--- a/AutoBid_FE/design/my_page/myPage.html
+++ b/AutoBid_FE/design/my_page/myPage.html
@@ -1,0 +1,225 @@
+<link rel="stylesheet" href="myPage.css">
+<body>
+<!-- MyPage Sidebar -->
+<div class="my-page__sidebar">
+    <h4 class="my-page__sidebar__title">마이 페이지</h4>
+    <hr>
+    <ul class="my-page__sidebar__div">
+        <li class="my-page__sidebar__greeting1">조재현 고객님</li>
+        <li class="my-page__sidebar__greeting2">반갑습니다.</li>
+        <li class="my-page__sidebar__phone-number">연락처: 010-1234-1234</li>
+        <li class="my-page__sidebar__email">이메일: hyunrice98@gmail.com</li>
+    </ul>
+</div>
+
+<!-- MyPage Main -->
+<ul class="my-page__main__ul">
+    <li class="my-page__main__card-list my-page__main__my-car-list__holder">
+        <h3>참여 경매</h3>
+        <hr>
+        <ol class="my-page__main__my-car-list">
+            <li class="main__card-list__grid__item">
+                <div class="main__card-list__grid__item__img-swap-btn-group">
+                    <button class="grid__item__img-swap-btn-group__btn">
+                        <i class="fas fa-chevron-left fa-lg"></i>
+                    </button>
+                    <button class="grid__item__img-swap-btn-group__btn">
+                        <i class="fas fa-chevron-right fa-lg"></i>
+                    </button>
+                </div>
+                <div class="main__card-list__grid__item__img-group">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                </div>
+                <div class="main__card-list__grid__item__details">
+                    <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                    <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                    <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
+                    <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
+                </div>
+            </li>
+            <li class="main__card-list__grid__item">
+                <div class="main__card-list__grid__item__img-swap-btn-group">
+                    <button class="grid__item__img-swap-btn-group__btn">
+                        <i class="fas fa-chevron-left fa-lg"></i>
+                    </button>
+                    <button class="grid__item__img-swap-btn-group__btn">
+                        <i class="fas fa-chevron-right fa-lg"></i>
+                    </button>
+                </div>
+                <div class="main__card-list__grid__item__img-group">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                </div>
+                <div class="main__card-list__grid__item__details">
+                    <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                    <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                    <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
+                    <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
+                </div>
+            </li>
+            <li class="main__card-list__grid__item">
+                <div class="main__card-list__grid__item__img-swap-btn-group">
+                    <button class="grid__item__img-swap-btn-group__btn">
+                        <i class="fas fa-chevron-left fa-lg"></i>
+                    </button>
+                    <button class="grid__item__img-swap-btn-group__btn">
+                        <i class="fas fa-chevron-right fa-lg"></i>
+                    </button>
+                </div>
+                <div class="main__card-list__grid__item__img-group">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                </div>
+                <div class="main__card-list__grid__item__details">
+                    <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                    <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                    <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
+                    <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
+                </div>
+            </li>
+        </ol>
+    </li>
+    <li class="my-page__main__card-list my-page__main__participating-bids__holder">
+        <h3>등록 경매</h3>
+        <hr>
+        <ol class="my-page__main__participating-bids">
+            <li class="main__card-list__grid__item">
+                <div class="main__card-list__grid__item__img-swap-btn-group">
+                    <button class="grid__item__img-swap-btn-group__btn">
+                        <i class="fas fa-chevron-left fa-lg"></i>
+                    </button>
+                    <button class="grid__item__img-swap-btn-group__btn">
+                        <i class="fas fa-chevron-right fa-lg"></i>
+                    </button>
+                </div>
+                <div class="main__card-list__grid__item__img-group">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                </div>
+                <div class="main__card-list__grid__item__details">
+                    <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                    <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                    <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
+                    <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
+                </div>
+            </li>
+            <li class="main__card-list__grid__item">
+                <div class="main__card-list__grid__item__img-swap-btn-group">
+                    <button class="grid__item__img-swap-btn-group__btn">
+                        <i class="fas fa-chevron-left fa-lg"></i>
+                    </button>
+                    <button class="grid__item__img-swap-btn-group__btn">
+                        <i class="fas fa-chevron-right fa-lg"></i>
+                    </button>
+                </div>
+                <div class="main__card-list__grid__item__img-group">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                </div>
+                <div class="main__card-list__grid__item__details">
+                    <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                    <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                    <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
+                    <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
+                </div>
+            </li>
+            <li class="main__card-list__grid__item">
+                <div class="main__card-list__grid__item__img-swap-btn-group">
+                    <button class="grid__item__img-swap-btn-group__btn">
+                        <i class="fas fa-chevron-left fa-lg"></i>
+                    </button>
+                    <button class="grid__item__img-swap-btn-group__btn">
+                        <i class="fas fa-chevron-right fa-lg"></i>
+                    </button>
+                </div>
+                <div class="main__card-list__grid__item__img-group">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                </div>
+                <div class="main__card-list__grid__item__details">
+                    <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                    <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                    <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
+                    <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
+                </div>
+            </li>
+        </ol>
+    </li>
+    <li class="my-page__main__card-list my-page__main__registered-bids__holder">
+        <h3>내 차 목록</h3>
+        <hr>
+        <ol class="my-page__main__registered-bids">
+            <li class="main__card-list__grid__item">
+                <div class="main__card-list__grid__item__img-swap-btn-group">
+                    <button class="grid__item__img-swap-btn-group__btn">
+                        <i class="fas fa-chevron-left fa-lg"></i>
+                    </button>
+                    <button class="grid__item__img-swap-btn-group__btn">
+                        <i class="fas fa-chevron-right fa-lg"></i>
+                    </button>
+                </div>
+                <div class="main__card-list__grid__item__img-group">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                </div>
+                <div class="main__card-list__grid__item__details">
+                    <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                    <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                    <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
+                    <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
+                </div>
+            </li>
+            <li class="main__card-list__grid__item">
+                <div class="main__card-list__grid__item__img-swap-btn-group">
+                    <button class="grid__item__img-swap-btn-group__btn">
+                        <i class="fas fa-chevron-left fa-lg"></i>
+                    </button>
+                    <button class="grid__item__img-swap-btn-group__btn">
+                        <i class="fas fa-chevron-right fa-lg"></i>
+                    </button>
+                </div>
+                <div class="main__card-list__grid__item__img-group">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                </div>
+                <div class="main__card-list__grid__item__details">
+                    <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                    <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                    <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
+                    <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
+                </div>
+            </li>
+            <li class="main__card-list__grid__item">
+                <div class="main__card-list__grid__item__img-swap-btn-group">
+                    <button class="grid__item__img-swap-btn-group__btn">
+                        <i class="fas fa-chevron-left fa-lg"></i>
+                    </button>
+                    <button class="grid__item__img-swap-btn-group__btn">
+                        <i class="fas fa-chevron-right fa-lg"></i>
+                    </button>
+                </div>
+                <div class="main__card-list__grid__item__img-group">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                    <img class="main__card-list__grid__item__img" src="https://picsum.photos/500" alt="">
+                </div>
+                <div class="main__card-list__grid__item__details">
+                    <span class="grid__item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                    <h4 class="grid__item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                    <span class="grid__item__details__infos">2018 | 142,852km | 가솔린 | 대전</span>
+                    <h3 class="grid__item__details__price"><b>1,090</b>만원</h3>
+                </div>
+            </li>
+        </ol>
+    </li>
+</ul>
+</body>


### PR DESCRIPTION
<!-- 해당 PR에서 달성한 이슈를 연결해 주세요 -->
<!-- 코드 리뷰를 해야하는 멤버를 등록해 주세요 -->
# 제목
마이페이지/내 차 목록 템플릿 구현

# 진행한 내용
Issue Link: #47 

- 마이페이지 화면에 표시될 사이드바 & 메인 화면 템플릿입니다.
- 사이드바가 약간 심심해보임
- 카드 내 이미지 슬라이더(?) 구현 필요

- [x] 템플릿 구현

# 코드리뷰 받고 싶은 부분 설명
@RandomlyChristen 여러 카드 섹션이 공존하기에, 부득이하게 카드 일부 margin/padding을 건드렸습니다. 기존 코드 틀과 큰 차이가 있다면 코멘트 부탁드려요.
