### PR TITLE
feat#131: 경매 가격 슬라이더 구현

### DIFF
--- a/AutoBid_FE/src/component/AnimatedNumber/AnimatedNumber.ts
+++ b/AutoBid_FE/src/component/AnimatedNumber/AnimatedNumber.ts
@@ -1,0 +1,21 @@
+const counters = document.getElementsByClassName("animated-number");
+const speed = 500;
+
+export default function AnimatedNumber() {
+    for (let c of counters) {
+        let counter = c as HTMLElement;
+        const animate = () => {
+            const value = +counter.getAttribute('value')!;
+            const data = +counter.innerText;
+
+            const time = value / speed;
+            if (data < value) {
+                counter.innerText = Math.ceil(data + time) + '';
+                setTimeout(animate, 1);
+            } else {
+                counter.innerText = value + '';
+            }
+        }
+        animate();
+    }
+}

--- a/AutoBid_FE/src/component/AnimatedNumber/AnimatedNumber.ts
+++ b/AutoBid_FE/src/component/AnimatedNumber/AnimatedNumber.ts
@@ -1,7 +1,7 @@
 const counters = document.getElementsByClassName("animated-number");
-const speed = 500;
+const speed = 2000;
 
-export default function AnimatedNumber() {
+export default async function AnimatedNumber() {
     for (let c of counters) {
         let counter = c as HTMLElement;
         const animate = () => {
@@ -16,6 +16,6 @@ export default function AnimatedNumber() {
                 counter.innerText = value + '';
             }
         }
-        animate();
+        await animate();
     }
 }

--- a/AutoBid_FE/src/component/AuctionCard/AuctionCard.ts
+++ b/AutoBid_FE/src/component/AuctionCard/AuctionCard.ts
@@ -4,6 +4,7 @@ import {CarInfo, getCarTypeName} from "../../model/car";
 import {Auction, AuctionStatus} from "../../model/auction";
 import "./auctioncard.css";
 import {deltaTimeToString} from "../../core/util";
+import AnimatedNumber from "../AnimatedNumber/AnimatedNumber";
 
 
 const getInfoStr = ({ distance, type, sellName }: CarInfo) =>
@@ -12,7 +13,7 @@ const getInfoStr = ({ distance, type, sellName }: CarInfo) =>
 class AuctionCard extends Component<any, { auction: Auction, onClick: (arg: any) => any }> {
     template(): InnerHTML["innerHTML"] {
         const { title, carInfo, status } = this.props.auction;
-        return `
+        const inner = `
         ${status === AuctionStatus.PROGRESS ? `<div class="ribbon"><span>입찰 진행 중</span></div>` : ''}
         ${status === AuctionStatus.COMPLETE ? `<div class="sold-out"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Pro 6.3.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d="M256 512c141.4 0 256-114.6 256-256S397.4 0 256 0S0 114.6 0 256S114.6 512 256 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"/></svg></div>` : ''}
         <div class="card-item__img-slider" data-component="ImageSlider"></div>
@@ -23,6 +24,8 @@ class AuctionCard extends Component<any, { auction: Auction, onClick: (arg: any)
             <h4 class="timer">계산 중</h4>
         </div>
         `;
+        AnimatedNumber();
+        return inner;
     }
 
     mounted() {
@@ -62,19 +65,19 @@ class AuctionCard extends Component<any, { auction: Auction, onClick: (arg: any)
             case AuctionStatus.BEFORE:
                 return `
                 <h3 class="card-item__details__price status--before">
-                    <em>시작가</em><b>${startPrice.toLocaleString()}</b>만원
+                    <em>시작가</em><b class="animated-number" value="${currPrice}">0</b>만원
                 </h3>
                 `;
             case AuctionStatus.COMPLETE:
                 return `
                 <h3 class="card-item__details__price status--complete">
-                    <em>낙찰가</em><b>${endPrice.toLocaleString()}</b>만원
+                    <em>낙찰가</em><b class="animated-number" value="${currPrice}">0</b>만원
                 </h3>
                 `;
             case AuctionStatus.PROGRESS:
                 return `
                 <h3 class="card-item__details__price status--progress">
-                    <em>입찰가</em><b>${currPrice.toLocaleString()}</b>만원
+                    <em>입찰가</em><b class="animated-number" value="${currPrice}">0</b>만원
                 </h3>
                 `;
         }

--- a/AutoBid_FE/src/component/AuctionCard/AuctionCard.ts
+++ b/AutoBid_FE/src/component/AuctionCard/AuctionCard.ts
@@ -24,7 +24,6 @@ class AuctionCard extends Component<any, { auction: Auction, onClick: (arg: any)
             <h4 class="timer">계산 중</h4>
         </div>
         `;
-        AnimatedNumber();
         return inner;
     }
 
@@ -86,6 +85,7 @@ class AuctionCard extends Component<any, { auction: Auction, onClick: (arg: any)
     initialize() {
         const { onClick } = this.props;
         this.addEvent('click', '.card-item__details-container', onClick);
+        AnimatedNumber();
     }
 }
 

--- a/AutoBid_FE/src/component/QuerySidebar/QuerySidebar.ts
+++ b/AutoBid_FE/src/component/QuerySidebar/QuerySidebar.ts
@@ -5,6 +5,7 @@ import {requestAuctionStatistic} from "../../api/statistic";
 import {Histogram} from "../../model/statistic";
 import {setRange} from "../../store/query";
 import "./querysidebar.css"
+import AnimatedNumber from "../AnimatedNumber/AnimatedNumber";
 
 class QuerySidebar extends Component<any> {
     template(): InnerHTML["innerHTML"] {
@@ -39,7 +40,7 @@ class QuerySidebar extends Component<any> {
             this.updateFundVal(auctionStatistic.minPrice, auctionStatistic.maxPrice);
             this.updateHistogram(auctionStatistic.histogram);
             this.mountDoubleRangeSlider(auctionStatistic.minPrice, auctionStatistic.maxPrice);
-        });
+        }).finally(AnimatedNumber);
     }
 
     markHistogramSelected(left: number, right: number, min: number, max: number) {
@@ -64,7 +65,7 @@ class QuerySidebar extends Component<any> {
 
     updateNSold(nSold: number) {
         const $nSold = this.$target.querySelector('.query-side-bar__n-sold') as HTMLElement;
-        $nSold.innerText = `오늘은 ${nSold}대가 판매되었습니다`;
+        $nSold.innerHTML = `오늘은 <b class="animated-number" value="${nSold}">0</b>대가 판매되었습니다`;
     }
     updateFundVal(min: number, max: number) {
         const minPriceInt = Math.floor(min);


### PR DESCRIPTION
<!-- 해당 PR에서 달성한 이슈를 연결해 주세요 -->
<!-- 코드 리뷰를 해야하는 멤버를 등록해 주세요 -->

# 진행한 내용
- [x] 가격 좌라라락 애니메이션 구현
- [x] 자동차 카드의 가격에 적용
- [x] 당일 판매 자동차량에 적용

# 특이사항
추후 현재 경매가 등에 추가 적용 필요

# 해당 컴포넌트 적용 방법
html 태그에 `class="animated-number" value="${WANTED_VALUE}"` 추가하기. innerHTML은 0으로 설정.
ex) `<b class="animated-number" value="${currPrice}">0</b>만원`
렌더링이 되는 ts 코드 상단에 `import AnimatedNumber from "~/AnimatedNumber";` 추가
렌더링 후 상의 ts 코드에, `AnimatedNumber()` 추가.
주의사항: 클래스는 무조건 animated-number이여야함