### PR TITLE
fix#113 delete token 메서드 기능 수정

### DIFF
--- a/AutoBid_BE/src/main/java/com/codesquad/autobid/user/controller/UserController.java
+++ b/AutoBid_BE/src/main/java/com/codesquad/autobid/user/controller/UserController.java
@@ -66,6 +66,7 @@ public class UserController {
         OauthToken deleteToken = authService.deleteOauthToken(accessToken);
         log.info("deleteToken : {}",deleteToken.getAccessToken());
         session.invalidate(); // 세션삭제
+        userService.remove(deleteToken); // 레디스에서 토큰 삭제
         return new ResponseEntity<>(HttpStatus.OK);
     }
 

--- a/AutoBid_BE/src/main/java/com/codesquad/autobid/user/service/UserService.java
+++ b/AutoBid_BE/src/main/java/com/codesquad/autobid/user/service/UserService.java
@@ -48,4 +48,10 @@ public class UserService {
         }
         return Optional.empty();
     }
+
+    public void remove(OauthToken oauthToken) {
+        UserVO userVO = userHandler.userProfileAPICall(oauthToken);
+        Optional<User> user = userRepository.findByUid(userVO.getId());
+        if(user.isPresent()) userRepository.delete(user.get());
+    }
 }


### PR DESCRIPTION
<!-- 해당 PR에서 달성한 이슈를 연결해 주세요 -->
<!-- 코드 리뷰를 해야하는 멤버를 등록해 주세요 -->

# 진행한 내용 : delete token 메서드 기능 수정

- [ ] 세부 구현 내용 1 : redis 에서 해쉬로 저장된 데이터 삭제

# 특이사항
