### PR TITLE
feat#168 경매 종료시 종료리본 만들기

### DIFF
--- a/AutoBid_FE/design/my_page/myPage.html
+++ b/AutoBid_FE/design/my_page/myPage.html
@@ -134,144 +134,236 @@
                 <button class="my-page__swap-button-right"><i class="fas fa-chevron-right"></i></button>
             </div>
         </li>
-        <!--        <li class="my-page__main__card-list my-page__main__participating-bids__holder">
-                    <h3>등록 경매</h3>
-                    <hr>
-                    <ol class="my-page__main__participating-bids">
-                        <li class="card-container__card-item">
-                            <div class="card-item__swap-button-container">
-                                <button class="card-item__swap-button-left">
-                                    <i class="fas fa-chevron-left fa-lg"></i>
-                                </button>
-                                <button class="card-item__swap-button-right">
-                                    <i class="fas fa-chevron-right fa-lg"></i>
-                                </button>
-                            </div>
-                            <div class="card-item__img-container">
-                                <img class="card-item__img" src="https://picsum.photos/300" alt="">
-                                <img class="card-item__img" src="https://picsum.photos/400" alt="">
-                                <img class="card-item__img" src="https://picsum.photos/500" alt="">
-                            </div>
-                            <div class="card-item__details-container">
-                                <span class="card-item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
-                                <h4 class="card-item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
-                                <span class="card-item__details__info">2018 | 142,852km | 가솔린 | 대전</span>
-                                <h3 class="card-item__details__price"><b>1,090</b>만원</h3>
-                            </div>
-                        </li>
-                        <li class="card-container__card-item">
-                            <div class="card-item__swap-button-container">
-                                <button class="card-item__swap-button-left">
-                                    <i class="fas fa-chevron-left fa-lg"></i>
-                                </button>
-                                <button class="card-item__swap-button-right">
-                                    <i class="fas fa-chevron-right fa-lg"></i>
-                                </button>
-                            </div>
-                            <div class="card-item__img-container">
-                                <img class="card-item__img" src="https://picsum.photos/300" alt="">
-                                <img class="card-item__img" src="https://picsum.photos/400" alt="">
-                                <img class="card-item__img" src="https://picsum.photos/500" alt="">
-                            </div>
-                            <div class="card-item__details-container">
-                                <span class="card-item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
-                                <h4 class="card-item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
-                                <span class="card-item__details__info">2018 | 142,852km | 가솔린 | 대전</span>
-                                <h3 class="card-item__details__price"><b>1,090</b>만원</h3>
-                            </div>
-                        </li>
-                        <li class="card-container__card-item">
-                            <div class="card-item__swap-button-container">
-                                <button class="card-item__swap-button-left">
-                                    <i class="fas fa-chevron-left fa-lg"></i>
-                                </button>
-                                <button class="card-item__swap-button-right">
-                                    <i class="fas fa-chevron-right fa-lg"></i>
-                                </button>
-                            </div>
-                            <div class="card-item__img-container">
-                                <img class="card-item__img" src="https://picsum.photos/300" alt="">
-                                <img class="card-item__img" src="https://picsum.photos/400" alt="">
-                                <img class="card-item__img" src="https://picsum.photos/500" alt="">
-                            </div>
-                            <div class="card-item__details-container">
-                                <span class="card-item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
-                                <h4 class="card-item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
-                                <span class="card-item__details__info">2018 | 142,852km | 가솔린 | 대전</span>
-                                <h3 class="card-item__details__price"><b>1,090</b>만원</h3>
-                            </div>
-                        </li>
-                    </ol>
-                </li>
-                <li class="my-page__main__card-list my-page__main__registered-bids__holder">
-                    <h3>내 차 목록</h3>
-                    <hr>
-                    <ol class="my-page__main__registered-bids">
-                        <li class="card-container__card-item">
-                            <div class="card-item__swap-button-container">
-                                <button class="card-item__swap-button-left">
-                                    <i class="fas fa-chevron-left fa-lg"></i>
-                                </button>
-                                <button class="card-item__swap-button-right">
-                                    <i class="fas fa-chevron-right fa-lg"></i>
-                                </button>
-                            </div>
-                            <div class="card-item__img-container">
-                                <img class="card-item__img" src="https://picsum.photos/300" alt="">
-                                <img class="card-item__img" src="https://picsum.photos/400" alt="">
-                                <img class="card-item__img" src="https://picsum.photos/500" alt="">
-                            </div>
-                            <div class="card-item__details-container">
-                                <span class="card-item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
-                                <h4 class="card-item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
-                                <span class="card-item__details__info">2018 | 142,852km | 가솔린 | 대전</span>
-                                <h3 class="card-item__details__price"><b>1,090</b>만원</h3>
-                            </div>
-                        </li>
-                        <li class="card-container__card-item">
-                            <div class="card-item__swap-button-container">
-                                <button class="card-item__swap-button-left">
-                                    <i class="fas fa-chevron-left fa-lg"></i>
-                                </button>
-                                <button class="card-item__swap-button-right">
-                                    <i class="fas fa-chevron-right fa-lg"></i>
-                                </button>
-                            </div>
-                            <div class="card-item__img-container">
-                                <img class="card-item__img" src="https://picsum.photos/300" alt="">
-                                <img class="card-item__img" src="https://picsum.photos/400" alt="">
-                                <img class="card-item__img" src="https://picsum.photos/500" alt="">
-                            </div>
-                            <div class="card-item__details-container">
-                                <span class="card-item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
-                                <h4 class="card-item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
-                                <span class="card-item__details__info">2018 | 142,852km | 가솔린 | 대전</span>
-                                <h3 class="card-item__details__price"><b>1,090</b>만원</h3>
-                            </div>
-                        </li>
-                        <li class="card-container__card-item">
-                            <div class="card-item__swap-button-container">
-                                <button class="card-item__swap-button-left">
-                                    <i class="fas fa-chevron-left fa-lg"></i>
-                                </button>
-                                <button class="card-item__swap-button-right">
-                                    <i class="fas fa-chevron-right fa-lg"></i>
-                                </button>
-                            </div>
-                            <div class="card-item__img-container">
-                                <img class="card-item__img" src="https://picsum.photos/300" alt="">
-                                <img class="card-item__img" src="https://picsum.photos/400" alt="">
-                                <img class="card-item__img" src="https://picsum.photos/500" alt="">
-                            </div>
-                            <div class="card-item__details-container">
-                                <span class="card-item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
-                                <h4 class="card-item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
-                                <span class="card-item__details__info">2018 | 142,852km | 가솔린 | 대전</span>
-                                <h3 class="card-item__details__price"><b>1,090</b>만원</h3>
-                            </div>
-                        </li>
-                    </ol>
-                </li> -->
+        <li class="my-page__main__section-holder my-page__main__participating-bids__holder">
+            <h3>등록 경매</h3>
+            <hr>
+            <div class="my-page__main__card-slider my-page__main__participating-bids">
+                <button class="my-page__swap-button-left"><i class="fas fa-chevron-left"></i></button>
+                <div class="my-page__card-list__holder">
+                    <div class="card-container__card-item">
+                        <div class="card-item__swap-button-container">
+                            <button class="card-item__swap-button-left">
+                                <i class="fas fa-chevron-left fa-lg"></i>
+                            </button>
+                            <button class="card-item__swap-button-right">
+                                <i class="fas fa-chevron-right fa-lg"></i>
+                            </button>
+                        </div>
+                        <div class="card-item__img-container">
+                            <img class="card-item__img" src="https://picsum.photos/300" alt="">
+                            <img class="card-item__img" src="https://picsum.photos/400" alt="">
+                            <img class="card-item__img" src="https://picsum.photos/500" alt="">
+                        </div>
+                        <div class="card-item__details-container">
+                            <span class="card-item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                            <h4 class="card-item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                            <span class="card-item__details__info">2018 | 142,852km | 가솔린 | 대전</span>
+                            <h3 class="card-item__details__price"><b>1,090</b>만원</h3>
+                        </div>
+                    </div>
+                    <div class="card-container__card-item">
+                        <div class="card-item__swap-button-container">
+                            <button class="card-item__swap-button-left">
+                                <i class="fas fa-chevron-left fa-lg"></i>
+                            </button>
+                            <button class="card-item__swap-button-right">
+                                <i class="fas fa-chevron-right fa-lg"></i>
+                            </button>
+                        </div>
+                        <div class="card-item__img-container">
+                            <img class="card-item__img" src="https://picsum.photos/300" alt="">
+                            <img class="card-item__img" src="https://picsum.photos/400" alt="">
+                            <img class="card-item__img" src="https://picsum.photos/500" alt="">
+                        </div>
+                        <div class="card-item__details-container">
+                            <span class="card-item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                            <h4 class="card-item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                            <span class="card-item__details__info">2018 | 142,852km | 가솔린 | 대전</span>
+                            <h3 class="card-item__details__price"><b>1,090</b>만원</h3>
+                        </div>
+                    </div>
+                    <div class="card-container__card-item">
+                        <div class="card-item__swap-button-container">
+                            <button class="card-item__swap-button-left">
+                                <i class="fas fa-chevron-left fa-lg"></i>
+                            </button>
+                            <button class="card-item__swap-button-right">
+                                <i class="fas fa-chevron-right fa-lg"></i>
+                            </button>
+                        </div>
+                        <div class="card-item__img-container">
+                            <img class="card-item__img" src="https://picsum.photos/300" alt="">
+                            <img class="card-item__img" src="https://picsum.photos/400" alt="">
+                            <img class="card-item__img" src="https://picsum.photos/500" alt="">
+                        </div>
+                        <div class="card-item__details-container">
+                            <span class="card-item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                            <h4 class="card-item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                            <span class="card-item__details__info">2018 | 142,852km | 가솔린 | 대전</span>
+                            <h3 class="card-item__details__price"><b>1,090</b>만원</h3>
+                        </div>
+                    </div>
+                    <div class="card-container__card-item">
+                        <div class="card-item__swap-button-container">
+                            <button class="card-item__swap-button-left">
+                                <i class="fas fa-chevron-left fa-lg"></i>
+                            </button>
+                            <button class="card-item__swap-button-right">
+                                <i class="fas fa-chevron-right fa-lg"></i>
+                            </button>
+                        </div>
+                        <div class="card-item__img-container">
+                            <img class="card-item__img" src="https://picsum.photos/300" alt="">
+                            <img class="card-item__img" src="https://picsum.photos/400" alt="">
+                            <img class="card-item__img" src="https://picsum.photos/500" alt="">
+                        </div>
+                        <div class="card-item__details-container">
+                            <span class="card-item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                            <h4 class="card-item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                            <span class="card-item__details__info">2018 | 142,852km | 가솔린 | 대전</span>
+                            <h3 class="card-item__details__price"><b>1,090</b>만원</h3>
+                        </div>
+                    </div>
+                    <div class="card-container__card-item">
+                        <div class="card-item__swap-button-container">
+                            <button class="card-item__swap-button-left">
+                                <i class="fas fa-chevron-left fa-lg"></i>
+                            </button>
+                            <button class="card-item__swap-button-right">
+                                <i class="fas fa-chevron-right fa-lg"></i>
+                            </button>
+                        </div>
+                        <div class="card-item__img-container">
+                            <img class="card-item__img" src="https://picsum.photos/300" alt="">
+                            <img class="card-item__img" src="https://picsum.photos/400" alt="">
+                            <img class="card-item__img" src="https://picsum.photos/500" alt="">
+                        </div>
+                        <div class="card-item__details-container">
+                            <span class="card-item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                            <h4 class="card-item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                            <span class="card-item__details__info">2018 | 142,852km | 가솔린 | 대전</span>
+                            <h3 class="card-item__details__price"><b>1,090</b>만원</h3>
+                        </div>
+                    </div>
+                </div>
+                <button class="my-page__swap-button-right"><i class="fas fa-chevron-right"></i></button>
+            </div>
+        </li>
+        <li class="my-page__main__section-holder my-page__main__registered-bids__holder">
+            <h3>내 차 목록</h3>
+            <hr>
+            <div class="my-page__main__card-slider my-page__main__registered-bids">
+                <button class="my-page__swap-button-left"><i class="fas fa-chevron-left"></i></button>
+                <div class="my-page__card-list__holder">
+                    <div class="card-container__card-item">
+                        <div class="card-item__swap-button-container">
+                            <button class="card-item__swap-button-left">
+                                <i class="fas fa-chevron-left fa-lg"></i>
+                            </button>
+                            <button class="card-item__swap-button-right">
+                                <i class="fas fa-chevron-right fa-lg"></i>
+                            </button>
+                        </div>
+                        <div class="card-item__img-container">
+                            <img class="card-item__img" src="https://picsum.photos/300" alt="">
+                            <img class="card-item__img" src="https://picsum.photos/400" alt="">
+                            <img class="card-item__img" src="https://picsum.photos/500" alt="">
+                        </div>
+                        <div class="card-item__details-container">
+                            <span class="card-item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                            <h4 class="card-item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                            <span class="card-item__details__info">2018 | 142,852km | 가솔린 | 대전</span>
+                            <h3 class="card-item__details__price"><b>1,090</b>만원</h3>
+                        </div>
+                    </div>
+                    <div class="card-container__card-item">
+                        <div class="card-item__swap-button-container">
+                            <button class="card-item__swap-button-left">
+                                <i class="fas fa-chevron-left fa-lg"></i>
+                            </button>
+                            <button class="card-item__swap-button-right">
+                                <i class="fas fa-chevron-right fa-lg"></i>
+                            </button>
+                        </div>
+                        <div class="card-item__img-container">
+                            <img class="card-item__img" src="https://picsum.photos/300" alt="">
+                            <img class="card-item__img" src="https://picsum.photos/400" alt="">
+                            <img class="card-item__img" src="https://picsum.photos/500" alt="">
+                        </div>
+                        <div class="card-item__details-container">
+                            <span class="card-item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                            <h4 class="card-item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                            <span class="card-item__details__info">2018 | 142,852km | 가솔린 | 대전</span>
+                            <h3 class="card-item__details__price"><b>1,090</b>만원</h3>
+                        </div>
+                    </div>
+                    <div class="card-container__card-item">
+                        <div class="card-item__swap-button-container">
+                            <button class="card-item__swap-button-left">
+                                <i class="fas fa-chevron-left fa-lg"></i>
+                            </button>
+                            <button class="card-item__swap-button-right">
+                                <i class="fas fa-chevron-right fa-lg"></i>
+                            </button>
+                        </div>
+                        <div class="card-item__img-container">
+                            <img class="card-item__img" src="https://picsum.photos/300" alt="">
+                            <img class="card-item__img" src="https://picsum.photos/400" alt="">
+                            <img class="card-item__img" src="https://picsum.photos/500" alt="">
+                        </div>
+                        <div class="card-item__details-container">
+                            <span class="card-item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                            <h4 class="card-item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                            <span class="card-item__details__info">2018 | 142,852km | 가솔린 | 대전</span>
+                            <h3 class="card-item__details__price"><b>1,090</b>만원</h3>
+                        </div>
+                    </div>
+                    <div class="card-container__card-item">
+                        <div class="card-item__swap-button-container">
+                            <button class="card-item__swap-button-left">
+                                <i class="fas fa-chevron-left fa-lg"></i>
+                            </button>
+                            <button class="card-item__swap-button-right">
+                                <i class="fas fa-chevron-right fa-lg"></i>
+                            </button>
+                        </div>
+                        <div class="card-item__img-container">
+                            <img class="card-item__img" src="https://picsum.photos/300" alt="">
+                            <img class="card-item__img" src="https://picsum.photos/400" alt="">
+                            <img class="card-item__img" src="https://picsum.photos/500" alt="">
+                        </div>
+                        <div class="card-item__details-container">
+                            <span class="card-item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                            <h4 class="card-item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                            <span class="card-item__details__info">2018 | 142,852km | 가솔린 | 대전</span>
+                            <h3 class="card-item__details__price"><b>1,090</b>만원</h3>
+                        </div>
+                    </div>
+                    <div class="card-container__card-item">
+                        <div class="card-item__swap-button-container">
+                            <button class="card-item__swap-button-left">
+                                <i class="fas fa-chevron-left fa-lg"></i>
+                            </button>
+                            <button class="card-item__swap-button-right">
+                                <i class="fas fa-chevron-right fa-lg"></i>
+                            </button>
+                        </div>
+                        <div class="card-item__img-container">
+                            <img class="card-item__img" src="https://picsum.photos/300" alt="">
+                            <img class="card-item__img" src="https://picsum.photos/400" alt="">
+                            <img class="card-item__img" src="https://picsum.photos/500" alt="">
+                        </div>
+                        <div class="card-item__details-container">
+                            <span class="card-item__details__tags">#1인신조 #완전무사고 #여성운전자</span>
+                            <h4 class="card-item__details__title">현대 아반떼MD 프리미어 1.6 GDi</h4>
+                            <span class="card-item__details__info">2018 | 142,852km | 가솔린 | 대전</span>
+                            <h3 class="card-item__details__price"><b>1,090</b>만원</h3>
+                        </div>
+                    </div>
+                </div>
+                <button class="my-page__swap-button-right"><i class="fas fa-chevron-right"></i></button>
+            </div>
+        </li>
     </ul>
 </div>
 </body>

--- a/AutoBid_FE/src/component/AuctionCard/AuctionCard.ts
+++ b/AutoBid_FE/src/component/AuctionCard/AuctionCard.ts
@@ -10,12 +10,15 @@ import "./auctioncard.css";
 const getInfoStr = ({ distance, type, sellName }: CarInfo) =>
     `${sellName} | ${distance.toLocaleString()}km | ${getCarTypeName(type)}`;
 
+
 class AuctionCard extends Component<any, { auction: Auction, onClick: (arg: any) => any }> {
     template(): InnerHTML["innerHTML"] {
         const { title, carInfo, status } = this.props.auction;
+        // Code for hammer (completed bid background)
+        // ${status === AuctionStatus.COMPLETED ? `<!--<div class="sold-out"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">&lt;!&ndash;! Font Awesome Pro 6.3.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. &ndash;&gt;<path d="M318.6 9.4c-12.5-12.5-32.8-12.5-45.3 0l-120 120c-12.5 12.5-12.5 32.8 0 45.3l16 16c12.5 12.5 32.8 12.5 45.3 0l4-4L325.4 293.4l-4 4c-12.5 12.5-12.5 32.8 0 45.3l16 16c12.5 12.5 32.8 12.5 45.3 0l120-120c12.5-12.5 12.5-32.8 0-45.3l-16-16c-12.5-12.5-32.8-12.5-45.3 0l-4 4L330.6 74.6l4-4c12.5-12.5 12.5-32.8 0-45.3l-16-16zm-152 288c-12.5-12.5-32.8-12.5-45.3 0l-112 112c-12.5 12.5-12.5 32.8 0 45.3l48 48c12.5 12.5 32.8 12.5 45.3 0l112-112c12.5-12.5 12.5-32.8 0-45.3l-1.4-1.4L272 285.3 226.7 240 168 298.7l-1.4-1.4z"/></svg></div>-->` : ''}
         return `
         ${status === AuctionStatus.PROGRESS ? `<div class="ribbon"><span>입찰 진행 중</span></div>` : ''}
-        ${status === AuctionStatus.COMPLETED ? `<div class="sold-out"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Pro 6.3.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d="M318.6 9.4c-12.5-12.5-32.8-12.5-45.3 0l-120 120c-12.5 12.5-12.5 32.8 0 45.3l16 16c12.5 12.5 32.8 12.5 45.3 0l4-4L325.4 293.4l-4 4c-12.5 12.5-12.5 32.8 0 45.3l16 16c12.5 12.5 32.8 12.5 45.3 0l120-120c12.5-12.5 12.5-32.8 0-45.3l-16-16c-12.5-12.5-32.8-12.5-45.3 0l-4 4L330.6 74.6l4-4c12.5-12.5 12.5-32.8 0-45.3l-16-16zm-152 288c-12.5-12.5-32.8-12.5-45.3 0l-112 112c-12.5 12.5-12.5 32.8 0 45.3l48 48c12.5 12.5 32.8 12.5 45.3 0l112-112c12.5-12.5 12.5-32.8 0-45.3l-1.4-1.4L272 285.3 226.7 240 168 298.7l-1.4-1.4z"/></svg></div>` : ''}
+        ${status === AuctionStatus.COMPLETED ? `<div class="ribbon red-ribbon"><span>입찰 완료</span></div>` : ''}
         <div class="card-item__img-slider" data-component="ImageSlider"></div>
         <div class="card-item__details-container">
             <h4 class="card-item__details__title">${title}</h4>

--- a/AutoBid_FE/src/style/ribbon.css
+++ b/AutoBid_FE/src/style/ribbon.css
@@ -1,49 +1,75 @@
 /*https://www.cssportal.com/css-ribbon-generator/*/
 .box {
-    width: 200px; height: 300px;
-    position: relative;
-    border: 1px solid #BBB;
-    background: #EEE;
+  background: #EEE;
+  border: 1px solid #BBB;
+  height: 300px;
+  position: relative;
+  width: 200px;
 }
+
 .ribbon {
-    position: absolute;
-    right: -5px; top: -5px;
-    z-index: 1;
-    overflow: hidden;
-    width: 75px; height: 75px;
-    text-align: right;
+  height: 75px;
+  overflow: hidden;
+  position: absolute;
+  right: -5px;
+  text-align: right;
+  top: -5px;
+  width: 75px;
+  z-index: 1;
 }
+
 .ribbon span {
-    font-size: 10px;
-    font-weight: bold;
-    color: #FFF;
-    text-transform: uppercase;
-    text-align: center;
-    line-height: 20px;
-    transform: rotate(45deg);
-    width: 100px;
-    display: block;
-    background: #79A70A;
-    background: linear-gradient(#2989d8 0%, #1e5799 100%);
-    box-shadow: 0 3px 10px -5px rgba(0, 0, 0, 1);
-    position: absolute;
-    top: 19px; right: -21px;
+  background: #79A70A;
+  background: linear-gradient(#2989d8 0%, #1e5799 100%);
+  box-shadow: 0 3px 10px -5px rgba(0, 0, 0, 1);
+  color: #FFF;
+  display: block;
+  font-size: 10px;
+  font-weight: bold;
+  line-height: 20px;
+  position: absolute;
+  right: -21px;
+  text-align: center;
+  text-transform: uppercase;
+  top: 19px;
+  transform: rotate(45deg);
+  width: 100px;
 }
+
 .ribbon span::before {
-    content: "";
-    position: absolute; left: 0; top: 100%;
-    z-index: -1;
-    border-left: 3px solid #1e5799;
-    border-right: 3px solid transparent;
-    border-bottom: 3px solid transparent;
-    border-top: 3px solid #1e5799;
+  border-bottom: 3px solid transparent;
+  border-left: 3px solid #1e5799;
+  border-right: 3px solid transparent;
+  border-top: 3px solid #1e5799;
+  content: "";
+  left: 0;
+  position: absolute;
+  top: 100%;
+  z-index: -1;
 }
+
 .ribbon span::after {
-    content: "";
-    position: absolute; right: 0; top: 100%;
-    z-index: -1;
-    border-left: 3px solid transparent;
-    border-right: 3px solid #1e5799;
-    border-bottom: 3px solid transparent;
-    border-top: 3px solid #1e5799;
+  border-bottom: 3px solid transparent;
+  border-left: 3px solid transparent;
+  border-right: 3px solid #1e5799;
+  border-top: 3px solid #1e5799;
+  content: "";
+  position: absolute;
+  right: 0;
+  top: 100%;
+  z-index: -1;
+}
+
+.red-ribbon span {
+  background: linear-gradient(#e07690 0%, #991e4d 100%);
+}
+
+.red-ribbon span::after {
+  border-right: 3px solid #991e4d;
+  border-top: 3px solid #991e4d;
+}
+
+.red-ribbon span::before {
+  border-left: 3px solid #991e4d;
+  border-top: 3px solid #991e4d;
 }


### PR DESCRIPTION
<!-- 해당 PR에서 달성한 이슈를 연결해 주세요 -->
<!-- 코드 리뷰를 해야하는 멤버를 등록해 주세요 -->

# 진행한 내용


ISSUE LINK: #168 
<img width="898" alt="asdf" src="https://user-images.githubusercontent.com/33449712/218953184-4f92ff79-0a1c-4c5e-81c4-8735c8dc61b1.png">

- [x] 빨간맛 리본 구현
- [x] 빨간맛 리본을 경매 완료된 카드에 표시하기

# 특이사항

주석친 망치 코드를 지울까말까 고민중